### PR TITLE
GIT-10: Fix Dead Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ Each departure object includes `time`, a unix timestamp of the next departure, t
 * _note you must be logged in to view the links below_
 
 [Using MTA Realtime Feeds](https://api.mta.info/#/HelpDocument)
-[The list of separate feed URLs](https://api.mta.info/sites/all/files/pdfs/GTFS-Realtime-NYC-Subway%20version%201%20dated%207%20Sep.pdf#/subwayRealTimeFeeds)
+[The list of separate feed URLs](https://api.mta.info/#/subwayRealTimeFeeds)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This is a JavaScript client for New York City's MTA GTFS-realtime Subway API.
 
-## Installation
+## 🚧 Installation
 
 ```bash
 npm install --save mta-realtime-subway-departures
 ```
 
-## Usage
+## ℹ️ Usage
 
 Call `client.departures()` with a subway complex ID to get the next subway departures leaving that station.
 
@@ -104,7 +104,7 @@ A `response` object includes subway departure data:
 
 ```
 
-### Response structure
+### 🔃 Response structure
 
 A response object contains the following properties:
 
@@ -117,7 +117,7 @@ A response object contains the following properties:
 
 Each departure object includes `time`, a unix timestamp of the next departure, the `routeId`, e.g. `A`, `C` or `E` train, and `destinationStationId` where the train is headed (see [mta-subway-stations](https://www.npmjs.com/package/mta-subway-stations) for a list of stations).
 
-## External Resources
+## 🌎 External Resources
 * _note you must be logged in to view the links below_
 
 [Using MTA Realtime Feeds](https://api.mta.info/#/HelpDocument)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ A response object contains the following properties:
 Each departure object includes `time`, a unix timestamp of the next departure, the `routeId`, e.g. `A`, `C` or `E` train, and `destinationStationId` where the train is headed (see [mta-subway-stations](https://www.npmjs.com/package/mta-subway-stations) for a list of stations).
 
 ## External Resources
+* _note you must be logged in to view the links below_
 
-[GTFS-realtime Reference for the New York City Subway](http://datamine.mta.info/sites/all/files/pdfs/GTFS-Realtime-NYC-Subway%20version%201%20dated%207%20Sep.pdf), a document that describes the fields in the API result.
-
-[The list of separate feed URLs](http://datamine.mta.info/list-of-feeds)
+[Using MTA Realtime Feeds](https://api.mta.info/#/HelpDocument)
+[The list of separate feed URLs](https://api.mta.info/sites/all/files/pdfs/GTFS-Realtime-NYC-Subway%20version%201%20dated%207%20Sep.pdf#/subwayRealTimeFeeds)


### PR DESCRIPTION
### Description: ✍️
* Updated `External Resources` section with links to new mta api website
* Added emojis... for fun 😄 
### Issue(s): 🎟️
* #10 

### Visual: 🔍
#### Before:
<img width="872" alt="Screen Shot 2020-10-02 at 10 23 41 AM" src="https://user-images.githubusercontent.com/710847/94934153-5a836500-0499-11eb-9210-ccba43a63d39.png">

#### After:
<img width="591" alt="Screen Shot 2020-10-02 at 10 22 56 AM" src="https://user-images.githubusercontent.com/710847/94934085-417ab400-0499-11eb-8df5-5f111c18b073.png">

### Reference(s): 📖
[api.mta.info](api.mta.info/)